### PR TITLE
Customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- colorTheme props (toolbarItemSelected & blockToolbarHoverText)
+
+### Changed
+- Editor prop theme -> colorTheme to avoid conflict with mui theme prop
+- colorTheme extends default theme instead of replacing
+- Editor 12px wider
+- BlockMenuItem does not change color on hover if selected
+- ToolbarMenu shows different color text for selected items
+- Command hotkeys wrapped with kbd
+
+### Fixed
+- BlockMenuItem now using colorTheme instead of default theme for icon and text
+- FloatingToolbar always at top (max z-index)
+- Command hotkey modifiers consistent and using full key names
+- Code blocks highlighted on Prism init even when value changes

--- a/src/components/BlockMenuItem.tsx
+++ b/src/components/BlockMenuItem.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import scrollIntoView from "smooth-scroll-into-view-if-needed";
 import styled, { withTheme } from "styled-components";
-import theme from "../styles/theme";
 
 export type Props = {
   selected: boolean;
   disabled?: boolean;
   onClick: () => void;
-  theme: typeof theme;
+  theme: Record<string, string>;
   icon?: typeof React.Component | React.FC<any>;
   title: React.ReactNode;
   shortcut?: string;
@@ -22,6 +21,7 @@ function BlockMenuItem({
   shortcut,
   icon,
   containerId = "block-menu-container",
+  theme,
 }: Props) {
   const Icon = icon;
 
@@ -60,7 +60,13 @@ function BlockMenuItem({
         </>
       )}
       {title}
-      {shortcut && <Shortcut>{shortcut}</Shortcut>}
+      {shortcut && (
+        <Shortcut>
+          {shortcut.split(" ").map(key => (
+            <kbd key={key}>{key}</kbd>
+          ))}
+        </Shortcut>
+      )}
     </MenuItem>
   );
 }
@@ -93,7 +99,8 @@ const MenuItem = styled.button<{
 
   &:hover,
   &:active {
-    color: ${props => props.theme.blockToolbarTextSelected};
+    color: ${props =>
+      props.selected ? undefined : props.theme.blockToolbarHoverText};
     background: ${props =>
       props.selected
         ? props.theme.blockToolbarSelectedBackground ||

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -589,7 +589,7 @@ export const Wrapper = styled.div<{
   box-sizing: border-box;
   pointer-events: none;
   white-space: nowrap;
-  width: 300px;
+  width: 312px;
   max-height: 224px;
   overflow: hidden;
   overflow-y: auto;

--- a/src/components/FloatingToolbar.tsx
+++ b/src/components/FloatingToolbar.tsx
@@ -185,7 +185,7 @@ const Wrapper = styled.div<{
   will-change: opacity, transform;
   padding: 8px 16px;
   position: absolute;
-  z-index: ${props => props.theme.zIndex + 100};
+  z-index: 99999;
   opacity: 0;
   background-color: ${props => props.theme.toolbarBackground};
   border-radius: 4px;

--- a/src/components/ToolbarMenu.tsx
+++ b/src/components/ToolbarMenu.tsx
@@ -45,7 +45,13 @@ class ToolbarMenu extends React.Component<Props> {
               active={isActive}
             >
               <Tooltip tooltip={item.tooltip} placement="top">
-                <Icon color={this.props.theme.toolbarItem} />
+                <Icon
+                  color={
+                    isActive
+                      ? this.props.theme.toolbarItemSelected
+                      : this.props.theme.toolbarItem
+                  }
+                />
               </Tooltip>
             </ToolbarButton>
           );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -126,7 +126,7 @@ export type Props = {
   dictionary?: Partial<typeof baseDictionary>;
   dark?: boolean;
   dir?: string;
-  theme?: typeof theme;
+  colorTheme?: typeof theme;
   template?: boolean;
   headingsOffset?: number;
   maxLength?: number;
@@ -720,7 +720,9 @@ class RichMarkdownEditor extends React.PureComponent<Props, State> {
   };
 
   theme = () => {
-    return this.props.theme || (this.props.dark ? darkTheme : lightTheme);
+    const baseTheme = this.props.dark ? darkTheme : lightTheme;
+
+    return { ...baseTheme, ...this.props.colorTheme };
   };
 
   dictionary = memoize(

--- a/src/lib/ComponentView.tsx
+++ b/src/lib/ComponentView.tsx
@@ -47,7 +47,7 @@ export default class ComponentView {
 
   renderElement() {
     const { dark } = this.editor.props;
-    const theme = this.editor.props.theme || (dark ? darkTheme : lightTheme);
+    const theme = this.editor.props.colorTheme || (dark ? darkTheme : lightTheme);
 
     const children = this.component({
       theme,

--- a/src/menus/block.ts
+++ b/src/menus/block.ts
@@ -21,7 +21,8 @@ import baseDictionary from "../dictionary";
 
 const SSR = typeof window === "undefined";
 const isMac = !SSR && window.navigator.platform === "MacIntel";
-const mod = isMac ? "⌘" : "ctrl";
+const ctrlMod = isMac ? "⌘" : "ctrl";
+const ctrlShiftMod = `${ctrlMod} shift`;
 
 export default function blockMenuItems(
   dictionary: typeof baseDictionary
@@ -32,7 +33,7 @@ export default function blockMenuItems(
       title: dictionary.h1,
       keywords: "h1 heading1 title",
       icon: Heading1Icon,
-      shortcut: "^ ⇧ 1",
+      shortcut: `${ctrlShiftMod} 1`,
       attrs: { level: 1 },
     },
     {
@@ -40,7 +41,7 @@ export default function blockMenuItems(
       title: dictionary.h2,
       keywords: "h2 heading2",
       icon: Heading2Icon,
-      shortcut: "^ ⇧ 2",
+      shortcut: `${ctrlShiftMod} 2`,
       attrs: { level: 2 },
     },
     {
@@ -48,7 +49,7 @@ export default function blockMenuItems(
       title: dictionary.h3,
       keywords: "h3 heading3",
       icon: Heading3Icon,
-      shortcut: "^ ⇧ 3",
+      shortcut: `${ctrlShiftMod} 3`,
       attrs: { level: 3 },
     },
     {
@@ -59,19 +60,19 @@ export default function blockMenuItems(
       title: dictionary.checkboxList,
       icon: TodoListIcon,
       keywords: "checklist checkbox task",
-      shortcut: "^ ⇧ 7",
+      shortcut: `${ctrlShiftMod} 7`,
     },
     {
       name: "bullet_list",
       title: dictionary.bulletList,
       icon: BulletedListIcon,
-      shortcut: "^ ⇧ 8",
+      shortcut: `${ctrlShiftMod} 8`,
     },
     {
       name: "ordered_list",
       title: dictionary.orderedList,
       icon: OrderedListIcon,
-      shortcut: "^ ⇧ 9",
+      shortcut: `${ctrlShiftMod} 9`,
     },
     {
       name: "separator",
@@ -86,20 +87,20 @@ export default function blockMenuItems(
       name: "blockquote",
       title: dictionary.quote,
       icon: BlockQuoteIcon,
-      shortcut: `${mod} ]`,
+      shortcut: `${ctrlMod} ]`,
     },
     {
       name: "code_block",
       title: dictionary.codeBlock,
       icon: CodeIcon,
-      shortcut: "^ ⇧ \\",
+      shortcut: `${ctrlShiftMod} \\`,
       keywords: "script",
     },
     {
       name: "hr",
       title: dictionary.hr,
       icon: HorizontalRuleIcon,
-      shortcut: `${mod} _`,
+      shortcut: `${ctrlMod} _`,
       keywords: "horizontal rule break line",
     },
     {
@@ -119,7 +120,7 @@ export default function blockMenuItems(
       name: "link",
       title: dictionary.link,
       icon: LinkIcon,
-      shortcut: `${mod} k`,
+      shortcut: `${ctrlMod} k`,
       keywords: "link url uri href",
     },
     {

--- a/src/plugins/Prism.ts
+++ b/src/plugins/Prism.ts
@@ -113,6 +113,7 @@ export default function Prism({ name }) {
     key: new PluginKey("prism"),
     state: {
       init: (_: Plugin, { doc }) => {
+        highlighted = false;
         return DecorationSet.create(doc, []);
       },
       apply: (transaction: Transaction, decorationSet, oldState, state) => {
@@ -137,6 +138,8 @@ export default function Prism({ name }) {
         // it render un-highlighted and then trigger a defered render of Prism
         // by updating the plugins metadata
         setTimeout(() => {
+          if (highlighted) { return; }
+
           view.dispatch(view.state.tr.setMeta("prism", { loaded: true }));
         }, 10);
       }

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -54,6 +54,7 @@ export const base = {
   blockToolbarTextSelected: colors.black,
   blockToolbarSelectedBackground: colors.greyMid,
   blockToolbarHoverBackground: colors.greyLight,
+  blockToolbarHoverText: undefined,
   blockToolbarDivider: colors.greyMid,
 
   noticeInfoBackground: "#F5BE31",
@@ -62,6 +63,8 @@ export const base = {
   noticeTipText: colors.white,
   noticeWarningBackground: "#FF5C80",
   noticeWarningText: colors.white,
+
+  toolbarItemSelected: colors.primary,
 };
 
 export const light = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,9 +2656,9 @@
   integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
 
 "@types/react-dom@^16.9.5":
-  version "16.9.14"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.14.tgz#674b8f116645fe5266b40b525777fc6bb8eb3bcd"
-  integrity sha512-FIX2AVmPTGP30OUJ+0vadeIFJJ07Mh1m+U0rxfgyW34p3rTlXI+nlenvAxNn4BP36YyI9IJ/+UJ7Wu22N1pI7A==
+  version "16.9.16"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.16.tgz#c591f2ed1c6f32e9759dfa6eb4abfd8041f29e39"
+  integrity sha512-Oqc0RY4fggGA3ltEgyPLc3IV9T73IGoWjkONbsyJ3ZBn+UPPCYpU2ec0i3cEbJuEdZtkqcCF2l1zf2pBdgUGSg==
   dependencies:
     "@types/react" "^16"
 
@@ -2669,10 +2669,19 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16", "@types/react@^16.9.19":
+"@types/react@*":
   version "16.14.21"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.21.tgz#35199b21a278355ec7a3c40003bd6a334bd4ae4a"
   integrity sha512-rY4DzPKK/4aohyWiDRHS2fotN5rhBSK6/rz1X37KzNna9HJyqtaGAbq9fVttrEPWF5ywpfIP1ITL8Xi2QZn6Eg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^16", "@types/react@^16.9.19":
+  version "16.14.28"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.14.28.tgz#073258f3fe7bb80c748842c1f93aeaafe16dffad"
+  integrity sha512-83zBE6+XUVXsdL3iFzOyUewdauaU+KviKCHEGOgSW52coAuqW7tEKQM0E9+ZC0Zk6TELQ2/JgogPvp7FavzFwg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -9529,13 +9538,13 @@ react-docgen@^5.0.0:
     strip-indent "^3.0.0"
 
 react-dom@^17.0.0:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.1.tgz#1de2560474ec9f0e334285662ede52dbc5426fc6"
-  integrity sha512-6eV150oJZ9U2t9svnsspTMrWNyHc6chX0KzDeAOXftRa8bNeOKTTfCJ7KorIwenkHd2xqVTBTCZd79yk/lx/Ug==
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.1"
+    scheduler "^0.20.2"
 
 react-draggable@^4.4.3:
   version "4.4.3"
@@ -9674,9 +9683,9 @@ react-textarea-autosize@^8.3.0:
     use-latest "^1.0.0"
 
 react@^17.0.0:
-  version "17.0.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.1.tgz#6e0600416bd57574e3f86d92edba3d9008726127"
-  integrity sha512-lG9c9UuMHdcAexXtigOZLX8exLWkW0Ku29qPRU8uhF2R9BN96dLCt0psvzPLlHc5OWkgymP3qwTRgbnw5BKx3w==
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -10134,10 +10143,10 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.1.tgz#da0b907e24026b01181ecbc75efdc7f27b5a000c"
-  integrity sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
* colorTheme props (toolbarItemSelected & blockToolbarHoverText)
* Editor prop theme -> colorTheme to avoid conflict with mui theme prop
* colorTheme extends default theme instead of replacing
* Editor 12px wider
* BlockMenuItem does not change color on hover if selected
* ToolbarMenu shows different color text for selected items
* Command hotkeys wrapped with kbd
* BlockMenuItem now using colorTheme instead of default theme for icon and text
* FloatingToolbar always at top (max z-index)
* Command hotkey modifiers consistent and using full key names
* Code blocks highlighted on Prism init even when value changes